### PR TITLE
update key_publisher.py and keys_to_twist.py

### DIFF
--- a/teleop_bot/key_publisher.py
+++ b/teleop_bot/key_publisher.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
   rospy.init_node("keyboard_driver")
   rate = rospy.Rate(100)
   # BEGIN TERMIOS
-  old_attr = termios.tcgetattr(sys.stdin)
+  old_attr = termios.tcgetattr(sys.stdin.fileno())
   tty.setcbreak(sys.stdin.fileno())
   # END TERMIOS
   print "Publishing keystrokes. Press Ctrl-C to exit..."

--- a/teleop_bot/keys_to_twist.py
+++ b/teleop_bot/keys_to_twist.py
@@ -12,7 +12,7 @@ key_mapping = { 'w': [ 0, 1], 'x': [0, -1],
 
 def keys_cb(msg, twist_pub):
   # BEGIN CB
-  if len(msg.data) == 0 or not key_mapping.has_key(msg.data[0]):
+  if len(msg.data) == 0 or not msg.data[0] in key_mapping:
     return # unknown key.
   vels = key_mapping[msg.data[0]]
   # END CB


### PR DESCRIPTION
1. The change in `key_publisher.py` enables me to run the code on Ubuntu 20.04 with python 
2. The change in `keys_to_twist` is necessary to get the code to run on python 3.x as `has_key()` method has been removed from python 3.x